### PR TITLE
Fix Issue #1 'bad octal number bug' for hours and minutes

### DIFF
--- a/src/tks/times.py
+++ b/src/tks/times.py
@@ -59,6 +59,16 @@ class TimeVar(tks.PickleVar):
 
         super(TimeVar, self).__init__(master, value, name)
 
+class DecimalVar(tk.StringVar):
+    """Return the value of the variable as a decimal integer, avoid errors with the '08...' and '09...' numbers."""
+    _default = 0
+    def get(self):
+        value = super().get()
+        try:
+            return int(value, base=10)
+        except (TypeError):
+            return int(float(value))
+
 
 class TimeEntry(ttk.Frame, object):
     """A time entry widget
@@ -126,8 +136,8 @@ class TimeEntry(ttk.Frame, object):
 
         self._locale = locale
 
-        self._hour_var = tk.IntVar()
-        self._minute_var = tk.IntVar()
+        self._hour_var = DecimalVar()
+        self._minute_var = DecimalVar()
         if show_seconds:
             self._second_var = tk.IntVar()
 


### PR DESCRIPTION
If the curent time is HH:08 or HH:09 (or 08:MM or 09:MM), the Time Entry fails and crashes (because 08 and 09 are bad octal literals).

(The error seems to be in the Tcl when it tries to interpret "08" or "09" as octal numbers?)

The proposed fix is 

- to add a DecimalVar class (based on tk.StringVar) to prevent Tcl's attempt to convert the string into a number;
- to use DecimalVar for **hours** and **minutes** entries.

