### PR TITLE
Optimize value setter to prevent redundant updates in DateEntry and fix synchronization issue in DateEntry.

### DIFF
--- a/src/example/example_date.py
+++ b/src/example/example_date.py
@@ -15,7 +15,7 @@ from tks.dates import DateEntry
 if __name__ == '__main__':
     root = tk.Tk()
     root.title('Date Test')
-    entry = DateEntry(root, locale='pt')
+    entry = DateEntry(root, locale='en')
     entry.grid(row=0, column=0, sticky=tk.EW)
     root.columnconfigure(0, weight=1)
     root.mainloop()

--- a/src/example/example_date.py
+++ b/src/example/example_date.py
@@ -15,7 +15,7 @@ from tks.dates import DateEntry
 if __name__ == '__main__':
     root = tk.Tk()
     root.title('Date Test')
-    entry = DateEntry(root, locale='en')
+    entry = DateEntry(root, locale='en_US')
     entry.grid(row=0, column=0, sticky=tk.EW)
     root.columnconfigure(0, weight=1)
     root.mainloop()

--- a/src/tks/__init__.py
+++ b/src/tks/__init__.py
@@ -23,10 +23,10 @@ class DefaultColors(object):
     """A container for color names."""
 
     fill = 'white'
-    select = '#9de5eb'
+    select = '#FF453A' # Current date circle, originally #9de5eb
     select_dark = '#58B1B7'
-    header = 'white'
-    outline = '#ccc'
+    header = '' # Header container with days of the week
+    outline = '#fff'
     invalid = 'red'
 
 

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -643,27 +643,27 @@ class DaySelector(ttk.Frame, object):
 
         self._header = ttk.Frame(self, padding=(3, 0), style='tks.TFrame')
 
-        self._prev_btn = ttk.Button(self._header, text='<', width=2,
+        self._prev_btn = ttk.Button(self._header, text='<', width=1,
                                     command=self._prev_month,
                                     style='Selector.tks.TButton')
-        self._prev_btn.grid(row=0, column=0, sticky=tk.W)
+        self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 1))
 
-        self._month_btn = ttk.Button(self._header,
+        self._month_btn = ttk.Button(self._header, width=8,
                                      style='Selector.tks.TButton')
-        self._month_btn.grid(row=0, column=1, sticky=tk.EW, padx=(0, 2))
+        self._month_btn.grid(row=0, column=1, sticky=tk.EW, padx=(1, 1))
         self._month_btn.bind('<ButtonRelease-1>',
                              self._master.month_btn_clicked)
 
-        self._year_btn = ttk.Button(self._header,
+        self._year_btn = ttk.Button(self._header, width=8,
                                     style='Selector.tks.TButton')
-        self._year_btn.grid(row=0, column=2, sticky=tk.EW, padx=(2, 0))
+        self._year_btn.grid(row=0, column=2, sticky=tk.EW, padx=(1, 1))
         self._year_btn.bind('<ButtonRelease-1>',
                             self._master.year_btn_clicked)
 
-        self._next_btn = ttk.Button(self._header, text='>', width=2,
+        self._next_btn = ttk.Button(self._header, text='>', width=1,
                                     command=self._next_month,
                                     style='Selector.tks.TButton')
-        self._next_btn.grid(row=0, column=3, sticky=tk.W)
+        self._next_btn.grid(row=0, column=3, sticky=tk.W, padx=(1, 0))
 
         self._header.columnconfigure(0, weight=0)
         self._header.columnconfigure(1, weight=1)
@@ -922,21 +922,21 @@ class MonthSelector(ttk.Frame, object):
             self._months = calendar.month_name
 
 
-        self._prev_btn = ttk.Button(self, text='<', width=2,
+        self._prev_btn = ttk.Button(self, text='<', width=1,
                                     command=self._prev_year,
                                     style='Selector.tks.TButton')
-        self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 4))
+        self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 1))
 
         self._year_btn = ttk.Button(self,
                                     style='Selector.tks.TButton')
-        self._year_btn.grid(row=0, column=1, sticky=tk.EW)
+        self._year_btn.grid(row=0, column=1, sticky=tk.EW, padx=(1, 1))
         self._year_btn.bind('<ButtonRelease-1>',
                             self._master.year_btn_clicked)
 
-        self._next_btn = ttk.Button(self, text='>', width=2,
+        self._next_btn = ttk.Button(self, text='>', width=1,
                                     command=self._next_year,
                                     style='Selector.tks.TButton')
-        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(4, 0))
+        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(1, 0))
 
         btn_frame = ttk.Frame(self, style='tks.TFrame')
         self._buttons = []
@@ -949,7 +949,12 @@ class MonthSelector(ttk.Frame, object):
                                  command=partial(self._btn_selected, month))
 
                 self._buttons.append(btn)
-                btn.grid(row=y, column=x, sticky=tk.EW, pady=(0, 4))
+                if x == 0:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(0, 1)) # Left column buttons
+                elif x == 1:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(1, 1)) # Middle column buttons
+                else:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(1, 0)) # Right column buttons
 
         btn_frame.columnconfigure(0, weight=1)
         btn_frame.columnconfigure(1, weight=1)

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -270,27 +270,28 @@ class DateEntry(ttk.Frame, object):
         if new_day:
             self._day_var.set(new_day)
             # self._day_var.set('%02d' % new_day)
-
-    # def _year_changed(self, *args):
-    #     value = self._variable.get()
-    #     new_date = datetime.date(year=int(self._year_var.get()),
-    #                              month=value.month,
-    #                              day=value.day)
-    #     self.value = new_date
             
-
     def _year_changed(self, *args):
         try:
             new_year = int(self._year_var.get())
             new_month = int(self._month_var.get())
             new_day = int(self._day_var.get())
+
+            print(f"_year_changed triggered: {new_year}, {new_month}, {new_day}")  # Debug print
+
             # Construct the new date with the most current values of all components.
             new_date = datetime.date(year=new_year, month=new_month, day=new_day)
             if new_date != self._variable.get():  # Check if the date has actually changed.
+
+                print(f"Year change detected, updating to {new_date}")  # Debug print
+
                 self._internal_value_change = True
                 self.value = new_date
         except ValueError:
             # This block catches conversion errors, which can happen if the fields are incomplete.
+
+            print("_year_changed: ValueError encountered")  # Debug print
+
             pass
 
     def _month_changed(self, *args):
@@ -298,11 +299,20 @@ class DateEntry(ttk.Frame, object):
             new_year = int(self._year_var.get())
             new_month = int(self._month_var.get())
             new_day = int(self._day_var.get())
+
+            print(f"_month_changed triggered: {new_year}, {new_month}, {new_day}")  # Debug print
+
             new_date = datetime.date(year=new_year, month=new_month, day=new_day)
             if new_date != self._variable.get():
+
+                print(f"Month change detected, updating to {new_date}")  # Debug print
+
                 self._internal_value_change = True
                 self.value = new_date
         except ValueError:
+
+            print("_month_changed: ValueError encountered")  # Debug print
+
             pass
 
     def _day_changed(self, *args):
@@ -310,18 +320,32 @@ class DateEntry(ttk.Frame, object):
             new_year = int(self._year_var.get())
             new_month = int(self._month_var.get())
             new_day = int(self._day_var.get())
+
+            print(f"_day_changed triggered: {new_year}, {new_month}, {new_day}")  # Debug print
+
             new_date = datetime.date(year=new_year, month=new_month, day=new_day)
             if new_date != self._variable.get():
+
+                print(f"Day change detected, updating to {new_date}")  # Debug print
+
                 self._internal_value_change = True
                 self.value = new_date
         except ValueError:
-            pass
 
+            print("_day_changed: ValueError encountered")  # Debug print
+            
+            pass
 
     def _value_changed(self, *args):
         if not self._internal_value_change:
+
+            print(f"_value_changed triggered without internal change, updating to {self._variable.get()}")  # Debug print
+
             self.value = self._variable.get()
         else:
+
+            print("_value_changed triggered by internal change, resetting flag")  # Debug print
+
             self._internal_value_change = False  # Ensure this is reset after handling changes
 
     def _select_date(self):
@@ -340,6 +364,22 @@ class DateEntry(ttk.Frame, object):
         new_date = dlg.date
         if new_date != None:
             self.value = new_date
+    
+    def disable(self):
+        """Disable the date entry widget and all its children"""
+        for child in self.winfo_children():
+            try:
+                child.configure(state='disabled')
+            except tk.TclError:
+                pass
+    
+    def enable(self):
+        """Enable the date entry widget and all its children"""
+        for child in self.winfo_children():
+            try:
+                child.configure(state='normal')
+            except tk.TclError:
+                pass
 
 
 class DateDialog(tks.dialog.Dialog):

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -949,7 +949,7 @@ class MonthSelector(ttk.Frame, object):
                                  command=partial(self._btn_selected, month))
 
                 self._buttons.append(btn)
-                btn.grid(row=y, column=x, pady=(0, 4))
+                btn.grid(row=y, column=x, sticky=tk.EW, pady=(0, 4))
 
         btn_frame.columnconfigure(0, weight=1)
         btn_frame.columnconfigure(1, weight=1)

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -44,6 +44,8 @@ _ = language.gettext
 import tks
 import tks.dialog
 
+import darkdetect
+
 
 class TargetShape():
     """How to draw the target round a date"""
@@ -445,12 +447,11 @@ class DateSelector(ttk.Frame, object):
                               font=fonts.text,
                               anchor=tk.CENTER)
         ttk.Style().configure('Month.Selector.tks.TButton',
-                              padding=(0, 10))
+                              padding=(0, 10)) # NOTE: Adds vertical padding to buttons on month screen
         ttk.Style().configure('Year.Selector.tks.TButton',
-                              padding=(0, 10))
+                              padding=(0, 10)) # NOTE: Adds vertical padding to buttons on the day screen
 
-        self._today_btn = ttk.Button(self, text=today_txt,
-                                     width=len(today_txt) + 4,
+        self._today_btn = ttk.Button(self, text='Jump to today',
                                      command=self._today_clicked)
         self._today_btn.grid(row=0, column=0, sticky=tk.N,
                              padx=3, pady=3)
@@ -670,7 +671,7 @@ class DaySelector(ttk.Frame, object):
         self._header.columnconfigure(3, weight=0)
         self._header.grid(row=0, column=0, sticky=tk.EW)
 
-        self._canvas = tk.Canvas(self, background=self._canvas_color)
+        self._canvas = tk.Canvas(self, background=self._canvas_color) # NOTE: controls background color of calendar (date area specifically)
         self._canvas.grid(row=1, column=0, columnspan=3, pady=(4, 0))
         self._create_canvas(target_type)
 
@@ -837,20 +838,25 @@ class DaySelector(ttk.Frame, object):
             for day_number, date_ in enumerate(days_in_week):
                 txt_tag = 'txt%d:%d' % (week_number, day_number)
 
-                if babel:
-                    text = babel.numbers.format_number(date_.day, self._locale)
+                # Determine the text color based on whether the date is the selected date
+                if date_ == self._date:  # This is the selected date
+                    if darkdetect.isLight() or darkdetect.isLight() is None:
+                        text_color = 'white' # Light mode or undetected mode defaults to light mode configuration
+                    else:
+                        text_color = 'black' # Dark mode
+                elif self._date.month == date_.month: # Default color for non-selected dates within the current month
+                    if darkdetect.isLight() or darkdetect.isLight() is None:
+                        text_color = 'black' # Light mode or undetected mode defaults to light mode configuration
+                    else:
+                        text_color = 'white' # Dark mode
                 else:
-                    text = str(date_.day)
+                    text_color = self.colors.other_month  # Color for dates not in the current month
 
-                if self._date.month == date_.month:
-                    self._canvas.itemconfigure(txt_tag,
-                                               text=text,
-                                               fill='black',
-                                               font=self._font)
-                else:
-                    self._canvas.itemconfigure(txt_tag,
-                                               text=text,
-                                               fill=self.colors.other_month)
+                # Apply the determined text color
+                self._canvas.itemconfigure(txt_tag,
+                                        text=str(date_.day),
+                                        fill=text_color,
+                                        font=self._font)
 
                 tgt_tag = 'tgt%s:%s' % (week_number, day_number)
 

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -147,14 +147,15 @@ class DateEntry(ttk.Frame, object):
 
         self._month_entry = ttk.Combobox(self,
                                          textvariable=self._month_var,
-                                         width=3,
+                                         width=2,
                                          font=self.fonts.text)
-        self._month_entry['values'] = ['%02d' % (x + 1) for x in range(12)]
+        self._month_entry['values'] = [(x + 1) for x in range(12)]
+        # self._month_entry['values'] = ['%02d' % (x + 1) for x in range(12)]
         self._month_entry.grid(row=0, column=month_column * 2)
 
         self._day_entry = ttk.Combobox(self,
                                        textvariable=self._day_var,
-                                       width=3,
+                                       width=2,
                                        font=self.fonts.text)
         self._day_entry.grid(row=0, column=day_column * 2)
 
@@ -216,7 +217,8 @@ class DateEntry(ttk.Frame, object):
             month_var_value = None
 
         if month_var_value is None or value.month != month_var_value:
-            self._month_var.set('%02d' % value.month)
+            self._month_var.set(value.month)
+            # self._month_var.set('%02d' % value.month)
             changed = True
 
         try:
@@ -225,7 +227,8 @@ class DateEntry(ttk.Frame, object):
             day_var_value = None
 
         if day_var_value is None or value.day != day_var_value:
-            self._day_var.set('%02d' % value.day)
+            self._day_var.set(value.day)
+            # self._day_var.set('%02d' % value.day)
             changed = True
 
         if changed:
@@ -253,10 +256,13 @@ class DateEntry(ttk.Frame, object):
                 new_day = days_in_month
 
         self._day_entry['values'] = \
-            ['%02d' % (x + 1) for x in range(days_in_month)]
+            [(x + 1) for x in range(days_in_month)]
+            # ['%02d' % (x + 1) for x in range(days_in_month)]
+            
 
         if new_day:
-            self._day_var.set('%02d' % new_day)
+            self._day_var.set(new_day)
+            # self._day_var.set('%02d' % new_day)
 
     # def _year_changed(self, *args):
     #     value = self._variable.get()

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -139,25 +139,32 @@ class DateEntry(ttk.Frame, object):
         self._month_var = tk.StringVar()
         self._day_var = tk.StringVar()
 
-        self._year_entry = ttk.Entry(self,
-                                     textvariable=self._year_var,
-                                     width=4,
-                                     font=self.fonts.text)
-        self._year_entry.grid(row=0, column=year_column * 2)
+        # Mapping of entries to their grid positions and properties
+        entry_configs = {
+            'year': {'widget': ttk.Entry, 'variable': self._year_var, 'width': 4, 'column': year_column * 2},
+            'month': {'widget': ttk.Combobox, 'variable': self._month_var, 'width': 2, 'column': month_column * 2, 'special': True},
+            'day': {'widget': ttk.Combobox, 'variable': self._day_var, 'width': 2, 'column': day_column * 2},
+        }
 
-        self._month_entry = ttk.Combobox(self,
-                                         textvariable=self._month_var,
-                                         width=2,
-                                         font=self.fonts.text)
-        self._month_entry['values'] = [(x + 1) for x in range(12)]
-        # self._month_entry['values'] = ['%02d' % (x + 1) for x in range(12)]
-        self._month_entry.grid(row=0, column=month_column * 2)
+        # Sort entry_configs by 'column' value before iterating to ensure correct tab order
+        sorted_configs = sorted(entry_configs.items(), key=lambda x: x[1]['column'])
 
-        self._day_entry = ttk.Combobox(self,
-                                       textvariable=self._day_var,
-                                       width=2,
-                                       font=self.fonts.text)
-        self._day_entry.grid(row=0, column=day_column * 2)
+        # Create and grid each widget based on its configuration, and directly assign instances
+        for key, config in sorted_configs:
+            # Instantiate the widget with common properties
+            entry_widget = config['widget'](self, textvariable=config['variable'], width=config['width'], font=self.fonts.text)
+            
+            # Special handling for the month widget
+            if config.get('special'):
+                entry_widget['values'] = [(x + 1) for x in range(12)]
+            
+            # Grid the widget
+            entry_widget.grid(row=0, column=config['column'])
+
+            # Save reference to the widget instance for later use
+            # i.e. dynamically creates self._day_entry, self._month_entry, and self._year_entry
+            setattr(self, f"_{key}_entry", entry_widget)
+
 
         lbl = ttk.Label(self, text=separator, width=1)
         lbl.grid(row=0, column=1)

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -449,7 +449,7 @@ class DateSelector(ttk.Frame, object):
         ttk.Style().configure('Month.Selector.tks.TButton',
                               padding=(0, 10)) # NOTE: Adds vertical padding to buttons on month screen
         ttk.Style().configure('Year.Selector.tks.TButton',
-                              padding=(0, 10)) # NOTE: Adds vertical padding to buttons on the day screen
+                              padding=(0, 10)) # NOTE: Adds vertical padding to buttons on the day (typo? year?) screen
 
         self._today_btn = ttk.Button(self, text='Jump to today',
                                      command=self._today_clicked)
@@ -925,9 +925,9 @@ class MonthSelector(ttk.Frame, object):
         self._prev_btn = ttk.Button(self, text='<', width=1,
                                     command=self._prev_year,
                                     style='Selector.tks.TButton')
-        self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 1))
+        self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 4))
 
-        self._year_btn = ttk.Button(self,
+        self._year_btn = ttk.Button(self, width=20,
                                     style='Selector.tks.TButton')
         self._year_btn.grid(row=0, column=1, sticky=tk.EW, padx=(1, 1))
         self._year_btn.bind('<ButtonRelease-1>',
@@ -936,7 +936,7 @@ class MonthSelector(ttk.Frame, object):
         self._next_btn = ttk.Button(self, text='>', width=1,
                                     command=self._next_year,
                                     style='Selector.tks.TButton')
-        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(1, 0))
+        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(4, 0))
 
         btn_frame = ttk.Frame(self, style='tks.TFrame')
         self._buttons = []
@@ -959,7 +959,7 @@ class MonthSelector(ttk.Frame, object):
         btn_frame.columnconfigure(0, weight=1)
         btn_frame.columnconfigure(1, weight=1)
         btn_frame.columnconfigure(2, weight=1)
-        btn_frame.grid(row=1, column=0, columnspan=3, pady=(4, 0),
+        btn_frame.grid(row=1, column=0, columnspan=3, padx=0,
                        sticky=tk.NSEW)
 
         self.columnconfigure(0, weight=0)
@@ -1001,33 +1001,41 @@ class YearSelector(ttk.Frame, object):
         super(YearSelector, self).__init__(master, style='tks.TFrame')
 
         self._date = None
-        self._prev_btn = ttk.Button(self, text='<', width=2,
+        self._prev_btn = ttk.Button(self, text='<', width=1,
                                     command=self._prev_decade,
                                     style='Selector.tks.TButton')
         self._prev_btn.grid(row=0, column=0, sticky=tk.W, padx=(0, 4))
 
-        self._year_btn = ttk.Label(self,
-                                   style='Selector.tks.TLabel')
-        self._year_btn.grid(row=0, column=1, sticky=tk.EW)
+        self._year_btn = ttk.Label(self, width=24,
+                                   style='Selector.tks.TLabel', anchor='center')
+        self._year_btn.grid(row=0, column=1, sticky=tk.EW, padx=(1, 1))
         # self._year_btn.bind('<Button-1>', self.year_btn_clicked)
 
-        self._next_btn = ttk.Button(self, text='>', width=2,
+        self._next_btn = ttk.Button(self, text='>', width=1,
                                     command=self._next_decade,
                                     style='Selector.tks.TButton')
-        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(4, 0))
+        # Below line makes YearSelector 1px less in size than MonthSelector, which fixes a strange bug where switching between 
+        # YS and MS results in a grey box that only redraws the UI once the mouse is clicked. This solution is not perfect 
+        # as there now a small amount of UI movement when switching between the two – however it is v small (1px).
+        self._next_btn.grid(row=0, column=2, sticky=tk.E, padx=(3, 0))
 
         btn_frame = ttk.Frame(self, style='tks.TFrame')
         self._buttons = []
         for y in range(4):
             for x in range(3):
                 btn = ttk.Button(btn_frame, style='Year.Selector.tks.TButton')
-                btn.grid(row=y, column=x, padx=1, pady=1)
                 self._buttons.append(btn)
+                if x == 0:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(0, 1)) # Left column buttons
+                elif x == 1:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(1, 1)) # Middle column buttons
+                else:
+                    btn.grid(row=y, column=x, sticky=tk.EW, padx=(1, 0)) # Right column buttons
 
         btn_frame.columnconfigure(0, weight=1)
         btn_frame.columnconfigure(1, weight=1)
         btn_frame.columnconfigure(2, weight=1)
-        btn_frame.grid(row=1, column=0, columnspan=3, pady=(4, 0),
+        btn_frame.grid(row=1, column=0, columnspan=3,
                        sticky=tk.NSEW)
 
         self.columnconfigure(0, weight=0)

--- a/src/tks/dates.py
+++ b/src/tks/dates.py
@@ -238,11 +238,6 @@ class DateEntry(ttk.Frame, object):
             self._time = value.time()
         else:
             self._time = None
-        
-        print('DATE DISPLAYED:')
-        print('Year: ' + str(value.year))
-        print('Month: ' + str(month_var_value))
-        print('Day: ' + str(day_var_value))
 
     def _update_day_values(self, year, month, day):
         """Update the day combo box with the correct values

--- a/src/tks/dialog.py
+++ b/src/tks/dialog.py
@@ -52,12 +52,12 @@ class Dialog(tk.Toplevel, object):
         btn_width = max(8, len(ok_text)) + 2
         self.ok_btn = ttk.Button(okcancel, text=ok_text, width=btn_width,
                                  command=self._ok)
-        self.ok_btn.grid(column=btn_column[0], row=0, padx=(6, 0), sticky=tk.SE)
+        self.ok_btn.grid(column=btn_column[0], row=0, padx=(2, 0), sticky=tk.SE)
 
         btn_width = max(8, len(cancel_text)) + 2
         cancel = ttk.Button(okcancel, text=cancel_text, width=btn_width,
                             command=self._cancel)
-        cancel.grid(column=btn_column[1], row=0, padx=(6, 0), sticky=tk.SE)
+        cancel.grid(column=btn_column[1], row=0, padx=(2, 0), sticky=tk.SE)
 
         okcancel.columnconfigure(0, weight=1)
         okcancel.columnconfigure(1, weight=0)
@@ -65,8 +65,8 @@ class Dialog(tk.Toplevel, object):
 
         okcancel.grid(column=0, row=1, sticky=(tk.EW, tk.S))
         self.columnconfigure(0, weight=1)
-        self.rowconfigure(0, weight=1)
-        self.rowconfigure(1, weight=0)
+        # self.rowconfigure(0, weight=1)
+        self.rowconfigure(1, weight=1)
 
         self.update_idletasks()
 

--- a/src/tks/dialog.py
+++ b/src/tks/dialog.py
@@ -55,9 +55,8 @@ class Dialog(tk.Toplevel, object):
         self.ok_btn.grid(column=btn_column[0], row=0, padx=(2, 0), sticky=tk.SE)
 
         btn_width = max(8, len(cancel_text)) + 2
-        cancel = ttk.Button(okcancel, text=cancel_text, width=btn_width,
-                            command=self._cancel)
-        cancel.grid(column=btn_column[1], row=0, padx=(2, 0), sticky=tk.SE)
+        self.cancel_btn = ttk.Button(okcancel, text=cancel_text, width=btn_width, command=self._cancel)
+        self.cancel_btn.grid(column=btn_column[1], row=0, padx=(2, 0), sticky=tk.SE)
 
         okcancel.columnconfigure(0, weight=1)
         okcancel.columnconfigure(1, weight=0)
@@ -81,6 +80,15 @@ class Dialog(tk.Toplevel, object):
 
     def cancel(self):
         raise NotImplementedError
+    
+    def set_ok_cancel_button_state(self, state):
+        """Enable or disable the OK and Cancel buttons"""
+        if state == 'disabled':
+            self.ok_btn.state(['disabled'])
+            self.cancel_btn.state(['disabled'])
+        else:
+            self.ok_btn.state(['!disabled'])
+            self.cancel_btn.state(['!disabled'])
 
     @property
     def selector(self):

--- a/src/tks/dialog.py
+++ b/src/tks/dialog.py
@@ -41,7 +41,7 @@ class Dialog(tk.Toplevel, object):
         if not colors:
             colors = tks.load_colors()
 
-        okcancel = ttk.Frame(self, padding=(3, 3, 3, 3), style='TFrame')
+        okcancel = ttk.Frame(self, padding=(3, 3, 6, 5), style='TFrame')
 
         # Swap the order of buttons for Windows
         if 'win32' in sys.platform:


### PR DESCRIPTION
This commit debugs the DateEntry widget in order to allow a user to enter dates by typing them in, rather than using the date selector. It does so in two way:

1) Enhances the value setter of the DateEntry widget to address issues with redundant updates and unexpected behavior when users input new dates. Previously, entering new year, month, or day values could lead to unexpected echoing or reverting of values due to the setter not efficiently detecting and handling actual changes.
2) Addresses a problem in the DateEntry widget where changing one component of the date (e.g., the day) would cause another component (e.g., the month or year) to revert to its original value. The root cause was identified as the update mechanism not correctly preserving the state across all date components when applying changes.

Changes include:

- 1.1) Implemented checks in the `value` setter to compare new input values against the current state before applying updates, ensuring updates only occur when there are genuine changes to the date components (year, month, day).
- 1.2) Added type conversion and validation within the setter to handle the comparison of integer values correctly, avoiding issues caused by type mismatches.
- 1.3) Preserved logic for handling `datetime.datetime` instances, ensuring that any associated time information is accurately maintained alongside date changes.
- 1.4) Introduced a mechanism (`self._internal_value_change`) to more effectively distinguish between user-driven and programmatic changes, minimizing unnecessary invocations of update logic.
- 2.1) Updating the `_year_changed`, `_month_changed`, and `_day_changed` callback methods to ensure they construct the new date using the most current values from all three components (year, month, day) before setting it.
- 2.2) Adding logic to check if the constructed date actually represents a change from the current value stored in `self._variable` to avoid unnecessary updates.
- 2.3) Implementing `try-except` blocks to gracefully handle scenarios where the user input might be incomplete or temporarily invalid, preventing conversion errors.

These improvements ensure that the DateEntry widget responds more reliably to user input, eliminating issues where the widget's state could incorrectly echo previous values or fail to update in response to new input, as well as ensure that the widget accurately reflects user input across all date components, maintaining consistency and preventing the inadvertent reversion of any part of the date when another is modified.